### PR TITLE
Fix the capacity of poolable

### DIFF
--- a/src/poolable.rs
+++ b/src/poolable.rs
@@ -9,7 +9,7 @@ pub trait Poolable {
 
 impl<T: Default + Clone> Poolable for Vec<T> {
     fn capacity(&self) -> usize {
-        self.capacity()
+        self.len()
     }
 
     fn alloc(size: usize) -> Self {

--- a/src/poolable.rs
+++ b/src/poolable.rs
@@ -23,7 +23,7 @@ where
     S: BuildHasher + Default,
 {
     fn capacity(&self) -> usize {
-        self.capacity()
+        self.len()
     }
 
     fn alloc(size: usize) -> Self {


### PR DESCRIPTION
I've tested this with the test suites of async-h1, async-imap, deltachat-rust-core and with my imapsyncer tool.  With this fix the latter is able to reliably download and synchronise 260k emails, without this fix the stream always gets stuck* at some point.

* depending on my local changes to async-imap "stuck" varies from an infinite loop to erroring out.  That's for another PR.

commit message:

A vector can allocate more space than the current number of elements,
this allows it to cheaply grow the elements.  This is what
vec.capacity() returns.  vec.len() returns the actual number of items
in use, this is also the number of items you will get when slicing
with e.g. vec[..].  This latter matters since this is how the block is
meant to be used: a lot of consumers silce the block.  Hence vec.len()
gives the actual capacity of the block.  This is also reflected with
how the block (re)allocates capacity: vec.resize() changes the Vec's
len with no guarantees how it affects the Vec capacity.