### PR TITLE
Update crossbeam-queue to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ is-it-maintained-open-issues = { repository = "dignifiedquire/byte-pool" }
 default = []
 
 [dependencies]
-crossbeam-queue = "0.2.0"
+crossbeam-queue = "0.3.1"
 stable_deref_trait = "1.1.1"

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -64,7 +64,7 @@ impl<T: Poolable> BytePool<T> {
         } else {
             &self.list_large
         };
-        if let Ok(el) = list.pop() {
+        if let Some(el) = list.pop() {
             if el.capacity() == size {
                 // found one, reuse it
                 return Block::new(el, self);


### PR DESCRIPTION
This avoids having two versions of crossbeam-queue in applications that
use byte-pool and recent crossbeam together.