### PR TITLE
Add repository link to Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "byte-pool"
 version = "0.2.2"
 authors = ["dignifiedquire <me@dignifiedquire.com>"]
+repository = "https://github.com/dignifiedquire/byte-pool"
 description = "Pool of byte slices, for efficient memory usage"
 edition = "2018"
 readme = "README.md"


### PR DESCRIPTION
This makes the repository easier to find via crates.io